### PR TITLE
Call Flask send_file() with absolute path

### DIFF
--- a/flask_server.py
+++ b/flask_server.py
@@ -91,7 +91,7 @@ class PathView(MethodView):
 
         elif os.path.isfile(path):
             print(path)
-            res = send_file(path, as_attachment=True)
+            res = send_file(os.path.abspath(path), as_attachment=True)
 
         else:
             res = make_response("Not found", 404)


### PR DESCRIPTION
Otherwise the path should be relative to Flask's `root_path`, which isn't set!

Without this change things look broken to me when I pass in anything but `~` for `--root`.