### PR TITLE
Improve file extension logic

### DIFF
--- a/cluster_fs/cluster_fs.py
+++ b/cluster_fs/cluster_fs.py
@@ -91,7 +91,7 @@ class PathView(MethodView):
 
         elif os.path.isfile(path):
             print(path)
-            res = send_file(os.path.abspath(path), as_attachment=True)
+            res = send_file(os.path.abspath(path))
 
         else:
             res = make_response("Not found", 404)

--- a/cluster_fs/cluster_fs.py
+++ b/cluster_fs/cluster_fs.py
@@ -23,10 +23,10 @@ def get_type(path):
         return "link"
 
     IMG_EXT = set([".jpg", ".jpeg", ".png", ".gif"])
-    VID_EXT = set([".mp4", ".webm"])
+    VID_EXT = set([".mp4", ".webm", ".mov"])
     GLB_EXT = set([".glb", ".gltf"])
 
-    ext = os.path.splitext(path)[-1]
+    ext = os.path.splitext(path)[-1].lower()
     if ext in IMG_EXT:
         return "image"
     if ext in VID_EXT:


### PR DESCRIPTION
Hi Vickie! Thanks for your wonderful tool!!

This PR:
- Adds support for previewing `.mov` files.
- Makes file extensions case-insensitive.
- Removes `as_attachment=True` from `send_file()`. This lets us right-click => Open Image in New Tab and preview a full-size image without downloading.